### PR TITLE
#9: Reduce messages if number ist higher than SQS can handle

### DIFF
--- a/src/SqsQueue.php
+++ b/src/SqsQueue.php
@@ -13,6 +13,7 @@ use LizardsAndPumpkins\Util\Storage\Clearable;
 
 class SqsQueue implements Queue, Clearable
 {
+    const MAX_AWS_SQS_CONSUMEABLE = 10;
     /**
      * @var SqsClient
      */
@@ -66,10 +67,14 @@ class SqsQueue implements Queue, Clearable
      */
     private function getMessages(int $numberOfMessagesToConsume): array
     {
+        if ($numberOfMessagesToConsume < 1) {
+            throw new \InvalidArgumentException('You need to consume at least one message.');
+        }
+
         $messages = $this->client->receiveMessage([
             'QueueUrl' => $this->queueUrl,
             'WaitTimeSeconds' => 20,
-            'MaxNumberOfMessages' => $numberOfMessagesToConsume,
+            'MaxNumberOfMessages' => min($numberOfMessagesToConsume, self::MAX_AWS_SQS_CONSUMEABLE),
         ])->get('Messages');
 
         return $messages ?? [];

--- a/src/SqsQueue.php
+++ b/src/SqsQueue.php
@@ -14,6 +14,7 @@ use LizardsAndPumpkins\Util\Storage\Clearable;
 class SqsQueue implements Queue, Clearable
 {
     const MAX_AWS_SQS_CONSUMEABLE = 10;
+
     /**
      * @var SqsClient
      */

--- a/tests/Integration/Suites/LizardsAndPumpkins/Messaging/Queue/Sqs/QueueAwsTest.php
+++ b/tests/Integration/Suites/LizardsAndPumpkins/Messaging/Queue/Sqs/QueueAwsTest.php
@@ -93,7 +93,7 @@ class QueueAwsTest extends TestCase
         $this->assertSame($message->serialize(), $returnedMessage->serialize());
     }
 
-    public function testMoreThan20MessagesComeBack()
+    public function testMoreThan10MessagesComeBack()
     {
         for ($i = 0; $i < 15; $i++) {
             $message = Message::withCurrentTime(


### PR DESCRIPTION
I'm not sure it is a good idea to just™ reduce the number of messages. But at this point the alternative would be to throw an exception.

The biggest problem I see is, if you expect 200 messages and don't check count() but instead if you get less then 200 stop processing. But I don't see how to handle this problem in a good way.

Happy about your feedback as well Marlon!

Closes #9 